### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/app/static/js/validation.js
+++ b/app/static/js/validation.js
@@ -59,12 +59,20 @@ const validation = {
     showError: (containerId, message) => {
         const container = document.getElementById(containerId);
         if (container) {
-            container.innerHTML = `
-                <div class="alert alert-danger alert-dismissible fade show">
-                    ${message}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            `;
+            const alertDiv = document.createElement('div');
+            alertDiv.className = "alert alert-danger alert-dismissible fade show";
+            
+            const messageSpan = document.createElement('span');
+            messageSpan.textContent = message;
+            alertDiv.appendChild(messageSpan);
+            
+            const closeButton = document.createElement('button');
+            closeButton.type = "button";
+            closeButton.className = "btn-close";
+            closeButton.setAttribute("data-bs-dismiss", "alert");
+            alertDiv.appendChild(closeButton);
+            
+            container.appendChild(alertDiv);
         }
     },
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ph4ntomByte/Study_Together/security/code-scanning/3](https://github.com/Ph4ntomByte/Study_Together/security/code-scanning/3)

To fix the issue, the `message` variable should be sanitized or escaped before being inserted into the DOM. This ensures that any potentially malicious content is neutralized and cannot execute as HTML or JavaScript. The best approach is to use a library like `DOMPurify` to sanitize the input or use `textContent` instead of `innerHTML` to safely insert plain text.

#### Steps to fix:
1. Replace `container.innerHTML` with `container.textContent` to ensure the `message` is treated as plain text.
2. Alternatively, use a library like `DOMPurify` to sanitize the `message` before inserting it into the DOM.

#### Required changes:
- Modify the `validation.showError` function in `app/static/js/validation.js` to use `textContent` instead of `innerHTML`.
- Ensure that the `message` is properly escaped or sanitized before being displayed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
