### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ph4ntomByte/Study_Together/security/code-scanning/4](https://github.com/Ph4ntomByte/Study_Together/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow does not appear to require write access to the repository, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only the permissions necessary for basic read operations, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
